### PR TITLE
New command: envdeployer:make-example 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   },
   "autoload": {
     "psr-4": {
-      "AlfredNutileInc\\PasswordResetter\\": "src/"
+      "AlfredNutileInc\\EnvDeployer\\": "src/"
     }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ This makes it super easy for local developers to merge their env to
 the different servers while at time keep a local .env and .env.example
 
 ~~~
-php artisan envdeployer:make_example
+php artisan envdeployer:make-example
 ~~~
 
 Would then setup example with random values

--- a/src/BuildArrayFromEnv.php
+++ b/src/BuildArrayFromEnv.php
@@ -40,7 +40,7 @@ class BuildArrayFromEnv
 
         $this->checkForFile();
 
-        $this->makeEvnArrayFromFile();
+        $this->makeEnvArrayFromFile();
 
         return $this->env;
     }
@@ -209,7 +209,7 @@ class BuildArrayFromEnv
         return $subString;
     }
 
-    private function makeEvnArrayFromFile()
+    private function makeEnvArrayFromFile()
     {
         /**
          * Thanks to Dotenv library by vlucas

--- a/src/BuildArrayFromEnv.php
+++ b/src/BuildArrayFromEnv.php
@@ -36,7 +36,7 @@ class BuildArrayFromEnv
 
     private function loadEnvFromFile()
     {
-        $this->filePath = base_path($this->env_name);
+        $this->setFilePath(base_path($this->env_name));
 
         $this->checkForFile();
 
@@ -185,6 +185,16 @@ class BuildArrayFromEnv
     public function setTargetEnv($target_env)
     {
         $this->target_env[] = $target_env;
+    }
+
+    public function setFilePath($filePath)
+    {
+        $this->filePath = $filePath;
+    }
+
+    public function getFilePath()
+    {
+        return $this->filePath;
     }
 
     private function checkForFile()

--- a/src/EnvDeployerCommand.php
+++ b/src/EnvDeployerCommand.php
@@ -14,7 +14,7 @@ class EnvDeployerCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'envdeploy:push {target}';
+    protected $signature = 'envdeployer:push {target}';
 
     /**
      * The console command description.

--- a/src/EnvDeployerMakeExampleCommand.php
+++ b/src/EnvDeployerMakeExampleCommand.php
@@ -1,0 +1,148 @@
+<?php namespace AlfredNutileInc\EnvDeployer;
+
+use AlfredNutileInc\EnvDeployer\Exceptions\FileNotFound;
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * Class EnvDeployerMakeExampleCommand
+ * @package AlfredNutileInc\EnvDeployer
+ */
+class EnvDeployerMakeExampleCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'envdeployer:make-example {--from=<base_path>/.env} {--to=<base_path>/.env.example}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Make an .env.example from the current .env';
+
+    /**
+     * @var BuildArrayFromEnv
+     */
+    protected $ba;
+
+    /**
+     * Create a new command instance.
+     */
+    public function __construct(BuildArrayFromEnv $ba)
+    {
+        parent::__construct();
+        $this->ba = $ba;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        list($from, $to) = $this->getFromToFilePaths();
+
+        $this->ba->setFilePath($from);
+        $this->ba->buildOutNewEnvArray();
+
+        $envSettings = $this->ba->getEnv();
+        $exampleSettings = [];
+
+        foreach ($envSettings as $setting) {
+            if ($this->isLineAComment($setting)) {
+                $exampleSettings[] = $setting;
+            } else {
+                list($name, $value) = $this->splitSettingStringIntoParts($setting);
+                $exampleSettings[] = $name . '=';
+            }
+        }
+
+        file_put_contents($to, implode("\n", $exampleSettings));
+
+        $this->info('Example has been updated: ' . $to);
+    }
+
+    /**
+     * Get the console command options.
+     * For compatibility with L5.0
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['from', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_REQUIRED, 'The file path for the source .env', base_path('.env')],
+            ['to', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_REQUIRED, 'The file path for the destination .env.example', base_path('.env.example')],
+        ];
+    }
+
+    /**
+     * Get the file paths for the source .env and destination .env.example.
+     *
+     * @return array
+     *
+     * @throws FileNotFound
+     */
+    private function getFromToFilePaths()
+    {
+        $from = $this->option('from');
+
+        if (empty($from)) {
+            $from = base_path('.env');
+        }
+
+        if (!file_exists($from)) {
+            throw new FileNotFound($from . ' - does not exist');
+        }
+
+        $to = $this->option('to');
+
+        if (empty($to)) {
+            $to = base_path('.env.example');
+        }
+
+        $parentDir = dirname($to);
+
+        if (!is_dir($parentDir)) {
+            throw new FileNotFound($parentDir . ' - does not exist');
+        }
+
+        return [$from, $to];
+    }
+
+    /**
+     * Split the setting string into an array of variable name and value.
+     * Thanks to https://github.com/vlucas/phpdotenv/blob/master/src/Loader.php
+     *
+     * @param string $setting
+     *
+     * @return array
+     */
+    private function splitSettingStringIntoParts($setting)
+    {
+        $name = '';
+        $value = '';
+        if (strpos($setting, '=') !== false) {
+            list($name, $value) = array_map('trim', explode('=', $setting, 2));
+        }
+        return array($name, $value);
+    }
+
+    /**
+     * Determine if a line is a comment.
+     *
+     * @param $line
+     *
+     * @return bool
+     */
+    private function isLineAComment($line)
+    {
+        return strpos($line, '#') === 0;
+    }
+}
+

--- a/src/EnvDeployerServiceProvider.php
+++ b/src/EnvDeployerServiceProvider.php
@@ -21,11 +21,17 @@ class EnvDeployerServiceProvider extends \Illuminate\Support\ServiceProvider
             }
         );
 
-        $this->commands('envdeployer.push');
+        $this->app['envdeployer.make-example'] = $this->app->share(
+            function ($app) {
+                return new EnvDeployerMakeExampleCommand(new BuildArrayFromEnv());
+            }
+        );
+
+        $this->commands('envdeployer.push', 'envdeployer.make-example');
     }
 
     public function provides()
     {
-        return ['envdeployer.push'];
+        return ['envdeployer.push', 'envdeployer.make-example'];
     }
 }

--- a/src/Exceptions/FileNotFound.php
+++ b/src/Exceptions/FileNotFound.php
@@ -1,0 +1,11 @@
+<?php namespace AlfredNutileInc\EnvDeployer\Exceptions;
+
+/**
+ * Class FileNotFound
+ * @package AlfredNutileInc\EnvDeployer\Exceptions
+ */
+
+class FileNotFound extends \Exception
+{
+
+}


### PR DESCRIPTION
`.env`:

```
# foobar
FOO_BAR=foo_bar
# foobar 2
FOO_BAR_2=foo_bar_2
```

`.env.example` will be:

```
# foobar
FOO_BAR=
# foobar 2
FOO_BAR_2=
```

The only thing is it doesn't preserve blank lines
