### PR TITLE
removed use of share() in favor of singleton implementation...

### DIFF
--- a/src/EnvDeployerServiceProvider.php
+++ b/src/EnvDeployerServiceProvider.php
@@ -1,6 +1,5 @@
 <?php namespace AlfredNutileInc\EnvDeployer;
 
-
 class EnvDeployerServiceProvider extends \Illuminate\Support\ServiceProvider
 {
 
@@ -15,17 +14,13 @@ class EnvDeployerServiceProvider extends \Illuminate\Support\ServiceProvider
 
     public function register()
     {
-        $this->app['envdeployer.push'] = $this->app->share(
-            function ($app) {
-                return new EnvDeployerCommand();
-            }
-        );
+        $this->app->singleton('envdeployer.push', function($app) {
+            return new EnvDeployerCommand();
+        });
 
-        $this->app['envdeployer.make-example'] = $this->app->share(
-            function ($app) {
-                return new EnvDeployerMakeExampleCommand(new BuildArrayFromEnv());
-            }
-        );
+        $this->app->singleton('envdeployer.make-example', function($app) {
+            return new EnvDeployerMakeExampleCommand(new BuildArrayFromEnv());
+        });
 
         $this->commands('envdeployer.push', 'envdeployer.make-example');
     }


### PR DESCRIPTION
Using the existing implementation on Larvel 5.4+ results in this error:

![image](https://user-images.githubusercontent.com/237335/32817096-e3c8e996-c970-11e7-90eb-1fba46815c30.png)

... because the share() method is [removed in Laravel 5.4](https://github.com/laravel/framework/commit/1a1969b6e6f793c3b2a479362641487ee9cbf736).